### PR TITLE
Add link to Kitely update giver

### DIFF
--- a/pages/home/updates.md
+++ b/pages/home/updates.md
@@ -10,11 +10,9 @@ toc: false
 
 If you have purchased AVsitter in Second Life, please collect the latest package by visiting our <a href="{{ site.inworld }}">location in Second Life</a> and click the update giver on the table. The latest packaged release is also sent when you rez the AVsitter package in Second Life.
 
-<!-- <h2>How to receive updates in Opensim</h2> Users of Kitely Market can use the Kitely {{ site.kitely }} redelivery service. -->
-
 ## Updates in OpenSim
 
-If you have purchased AVsitter from Kitely Market, updates can be requested manually by contacting <i>AVsitter Resident</i> in Kitely.
+If you have purchased AVsitter from Kitely Market, updates can be collected by visiting <a href="hop://grid.kitely.com:8002/AVsitter%20sandbox/128/127/23">AVsitter sandbox</a> region in Kitely and clicking on the update giver in the center of the sim.
 
 ## Notes about updates
 


### PR DESCRIPTION
Unfortunately there doesn't seem to be a straight-forward and reliable way to completely automate redelivery in Hypergrid for users who choose to purchase through Kitely Market. I have however placed an update giver in the 'AVsitter sandbox' region of Kitely where avatars can get the latest packaged OpenSim version. Whenever an avatar receives the package from Kitely market their details are manually added to the update giver. After this, they've been added, they can return at any time to click the updater to get the latest package.