### PR TITLE
add team info

### DIFF
--- a/pages/home/support.md
+++ b/pages/home/support.md
@@ -27,14 +27,28 @@ If you have a Marketplace or purchase related enquiry please contact <a href="ht
 # Development/Support Team
 The current Development/Support Team consists of the following members:
 
-* <i>(wanted)</i> - Inworld Group Moderators
-* <i>(wanted)</i> - Code Developers
-* <i>(wanted)</i> - Second Life Release Tester
-* <i>(wanted)</i> - OpenSim Release Tester
-* <a href="http://world.secondlife.com/resident/766f3817-2f2a-469d-acfa-9789080ecc85">Auryn Beorn</a> - Documentation Maintainer
-* <a href="http://world.secondlife.com/resident/3c5aaad5-8c66-46a3-b574-cad02acf520d">Sei Lisa</a> - Lead Developer / Project Maintainer 
-* <a href="http://world.secondlife.com/resident/b30c9262-9abf-4cd1-9476-adcf5723c029">Code Violet</a> - Project Management / Project Creator
-* <a href="http://world.secondlife.com/resident/8c24c939-bbe9-4bd0-8868-b5b92cc90bc9">AVsitter Resident</a> - Marketplace Enquiries
+### Inworld Group Support:
+  * *(wanted)*
+
+### Second Life Release Tester:
+  * *(wanted)*
+
+### OpenSim Release Tester:
+  * *(wanted)*
+
+### Code Developers:
+  * [Sei Lisa](http://world.secondlife.com/resident/3c5aaad5-8c66-46a3-b574-cad02acf520d) (Lead Developer / Project Maintainer)
+  * *(wanted)*
+
+### Documentation Maintainer:
+  * [Auryn Beorn](http://world.secondlife.com/resident/766f3817-2f2a-469d-acfa-9789080ecc85)
+
+### Project Management:
+  * [Code Violet](http://world.secondlife.com/resident/b30c9262-9abf-4cd1-9476-adcf5723c029)
+
+### Marketplace Enquiries:
+  * [AVsitter Resident](http://world.secondlife.com/resident/8c24c939-bbe9-4bd0-8868-b5b92cc90bc9)
+
 
 {% include important.html content="Team members work on a voluntary basis and are not required to assist you with your project. If you are reaching out for help please ask nicely and respect their time!" %}
 

--- a/pages/home/support.md
+++ b/pages/home/support.md
@@ -1,5 +1,5 @@
 ---
-title: Support
+title: AVsitter Support
 sidebar: home_sidebar
 keywords: support
 permalink: support.html
@@ -13,7 +13,7 @@ If you need advice with using AVsitter, we suggest:
 -  Study the <a href="https://avsitter.github.io">instructions</a> including the <a href="https://www.youtube.com/user/code5violet/videos">tutorials on youtube</a>.
 -  Examine the <a href="/avsitter2_examples.html">example items</a> found inside the AVsitter Examples [BOX] (included in the <a href="{{ site.marketplace }}">packaged edition</a>).
 -  Search the <a href="https://avsitter.com/qa">AVsitter support Q&A website archive</a> where many questions were answered.
--  Join <a href="secondlife:///app/group/ccd07e24-4fdd-750f-f28f-fadd795d32ca/about">Unofficial AVsitter Support Group</a> in Second Life, where community members may be able to help. If you don't receive an immediate answer, try again at another time when other users are online.
+-  Join <a href="http://world.secondlife.com/group/ccd07e24-4fdd-750f-f28f-fadd795d32ca">Unofficial AVsitter Support Group</a> in Second Life, where community members may be able to help. If you don't receive an immediate answer, try again at another time when other users are online.
 -  Follow the <a href="/news_archive.html">news page</a> for information about future development.
 
 ## Reporting code & documentation bugs
@@ -21,8 +21,28 @@ If you need advice with using AVsitter, we suggest:
 -  Code bugs can be reported on the <a href="https://github.com/AVsitter/AVsitter/issues">AVsitter GitHub issues page</a>.
 -  For AVsitter Documentation issues please use the <a href="https://github.com/AVsitter/avsitter.github.io/issues">AVsitter Documentation GitHub issues page</a>.
 
-## Purchase enquiries
-If you have a Marketplace or purchase related enquiry please contact <u>AVsitter Resident</u> with a full description. Messages will be checked every 3-4 days, so please be patient awaiting a response.
+## Marketplace enquiries
+If you have a Marketplace or purchase related enquiry please contact <a href="http://world.secondlife.com/resident/8c24c939-bbe9-4bd0-8868-b5b92cc90bc9">AVsitter Resident</a> with a full description. Messages will be checked every 3-4 days, so please be patient awaiting a response.
 
-## Contribute to AVsitter support
-If you want to get involved in the development of the AVsitter scripts or documentation please see the <a href="/contribute">contributor guidelines</a> page.
+# Development/Support Team
+The current Development/Support Team consists of the following members:
+
+* <i>(wanted)</i> - Inworld Group Moderators
+* <i>(wanted)</i> - Code Developers
+* <i>(wanted)</i> - Second Life Release Tester
+* <i>(wanted)</i> - OpenSim Release Tester
+* <a href="http://world.secondlife.com/resident/766f3817-2f2a-469d-acfa-9789080ecc85">Auryn Beorn</a> - Documentation Maintainer
+* <a href="http://world.secondlife.com/resident/3c5aaad5-8c66-46a3-b574-cad02acf520d">Sei Lisa</a> - Lead Developer / Project Maintainer 
+* <a href="http://world.secondlife.com/resident/b30c9262-9abf-4cd1-9476-adcf5723c029">Code Violet</a> - Project Management / Project Creator
+* <a href="http://world.secondlife.com/resident/8c24c939-bbe9-4bd0-8868-b5b92cc90bc9">AVsitter Resident</a> - Marketplace Enquiries
+
+{% include important.html content="Team members work on a voluntary basis and are not required to assist you with your project. If you are reaching out for help please ask nicely and respect their time!" %}
+
+
+## Joining the Team?
+* If you are making significant ongoing contributions to the AVsitter ecosystem you may contact <a href="http://world.secondlife.com/resident/3c5aaad5-8c66-46a3-b574-cad02acf520d">Sei Lisa</a> and request you be considered for addition to the team.
+
+* Distributions received from the sale of the official packaged AVsitter are shared with the project team (adjusted periodically by Project Management based on recent/ongoing activity).
+
+* For code/documentation contributions please follow the <a href="/contribute">contributor guidelines</a>.
+


### PR DESCRIPTION
Before merging, I would appreciate any feedback about the treatment I've given the team section. e.g. If there's an obvious way to do it better, etc. Hopefully it is all ok :) If we find people asking direct questions too much before researching the documentation then perhaps in future the team info could be moved to a different page other than /support.