### PR TITLE
Update the show/hide example scripts to support PBR

### DIFF
--- a/_avsitter2_lsl_examples_advanced/avsitter2_lsl_example_show_and_hide_prim_by_button.md
+++ b/_avsitter2_lsl_examples_advanced/avsitter2_lsl_example_show_and_hide_prim_by_button.md
@@ -23,9 +23,11 @@ default {
         if(msg==button_name){
             if(visible){
                 llSetAlpha(0,ALL_SIDES);//invisible
+                llSetLinkPrimitiveParamsFast(LINK_THIS, [PRIM_GLTF_BASE_COLOR, ALL_SIDES, "", "", "", "", "", 0.0, PRIM_GLTF_ALPHA_MODE_MASK, 1.0, ""]);
             }
             else{
                 llSetAlpha(1,ALL_SIDES);//visible
+                llSetLinkPrimitiveParamsFast(LINK_THIS, [PRIM_GLTF_BASE_COLOR, ALL_SIDES, "", "", "", "", "", "", "", "", ""]);
             }
             llMessageLinked(LINK_SET,90005,"",id); // give back the menu
             visible=!visible;

--- a/_avsitter2_lsl_examples_advanced/avsitter2_lsl_example_show_and_hide_prim_by_pose.md
+++ b/_avsitter2_lsl_examples_advanced/avsitter2_lsl_example_show_and_hide_prim_by_pose.md
@@ -27,11 +27,13 @@ default{
             if(SITTER==-1 || SITTER==SITTER_NUMBER){
                 string POSE_NAME = llList2String(data,1);
                 if(llListFindList(POSES,[POSE_NAME])!=-1){
-                    llSetAlpha(0,ALL_SIDES);//invisible
-                }
-                else{
-                    llSetAlpha(1,ALL_SIDES);//visible
-                }
+            if(visible){
+                llSetAlpha(0,ALL_SIDES);//invisible
+                llSetLinkPrimitiveParamsFast(LINK_THIS, [PRIM_GLTF_BASE_COLOR, ALL_SIDES, "", "", "", "", "", 0.0, PRIM_GLTF_ALPHA_MODE_MASK, 1.0, ""]);
+            }
+            else{
+                llSetAlpha(1,ALL_SIDES);//visible
+                llSetLinkPrimitiveParamsFast(LINK_THIS, [PRIM_GLTF_BASE_COLOR, ALL_SIDES, "", "", "", "", "", "", "", "", ""]);
             }
         }
         else if(num==90065){//sitter stands up

--- a/_avsitter2_lsl_examples_advanced/avsitter2_lsl_example_show_and_hide_prim_by_pose.md
+++ b/_avsitter2_lsl_examples_advanced/avsitter2_lsl_example_show_and_hide_prim_by_pose.md
@@ -27,13 +27,13 @@ default{
             if(SITTER==-1 || SITTER==SITTER_NUMBER){
                 string POSE_NAME = llList2String(data,1);
                 if(llListFindList(POSES,[POSE_NAME])!=-1){
-            if(visible){
-                llSetAlpha(0,ALL_SIDES);//invisible
-                llSetLinkPrimitiveParamsFast(LINK_THIS, [PRIM_GLTF_BASE_COLOR, ALL_SIDES, "", "", "", "", "", 0.0, PRIM_GLTF_ALPHA_MODE_MASK, 1.0, ""]);
-            }
-            else{
-                llSetAlpha(1,ALL_SIDES);//visible
-                llSetLinkPrimitiveParamsFast(LINK_THIS, [PRIM_GLTF_BASE_COLOR, ALL_SIDES, "", "", "", "", "", "", "", "", ""]);
+                    llSetAlpha(0,ALL_SIDES);//invisible
+                    llSetLinkPrimitiveParamsFast(LINK_THIS, [PRIM_GLTF_BASE_COLOR, ALL_SIDES, "", "", "", "", "", 0.0, PRIM_GLTF_ALPHA_MODE_MASK, 1.0, ""]);
+                }
+                else{
+                    llSetAlpha(1,ALL_SIDES);//visible
+                    llSetLinkPrimitiveParamsFast(LINK_THIS, [PRIM_GLTF_BASE_COLOR, ALL_SIDES, "", "", "", "", "", "", "", "", ""]);
+                }
             }
         }
         else if(num==90065){//sitter stands up

--- a/_avsitter2_lsl_examples_advanced/avsitter2_lsl_example_show_and_hide_prim_by_sit.md
+++ b/_avsitter2_lsl_examples_advanced/avsitter2_lsl_example_show_and_hide_prim_by_sit.md
@@ -17,11 +17,13 @@ default{
             if(llGetAgentSize(llGetLinkKey(llGetNumberOfPrims()))==ZERO_VECTOR){
                 //make prim visible
                 llSetAlpha(1,ALL_SIDES);
+                llSetLinkPrimitiveParamsFast(LINK_THIS, [PRIM_GLTF_BASE_COLOR, ALL_SIDES, "", "", "", "", "", "", "", "", ""]);
             }
             // if avatars are sitting
             else{
                 //make prim invisible
                 llSetAlpha(0,ALL_SIDES);
+                llSetLinkPrimitiveParamsFast(LINK_THIS, [PRIM_GLTF_BASE_COLOR, ALL_SIDES, "", "", "", "", "", "", "", "", ""]);
             }
         }
     }

--- a/_avsitter2_lsl_examples_advanced/avsitter2_lsl_example_show_and_hide_prim_by_sit.md
+++ b/_avsitter2_lsl_examples_advanced/avsitter2_lsl_example_show_and_hide_prim_by_sit.md
@@ -23,7 +23,7 @@ default{
             else{
                 //make prim invisible
                 llSetAlpha(0,ALL_SIDES);
-                llSetLinkPrimitiveParamsFast(LINK_THIS, [PRIM_GLTF_BASE_COLOR, ALL_SIDES, "", "", "", "", "", "", "", "", ""]);
+                llSetLinkPrimitiveParamsFast(LINK_THIS, [PRIM_GLTF_BASE_COLOR, ALL_SIDES, "", "", "", "", "", 0.0, PRIM_GLTF_ALPHA_MODE_MASK, 1.0, ""]);
             }
         }
     }

--- a/_avsitter2_lsl_examples_advanced/avsitter2_lsl_example_show_and_hide_prim_by_sittarget.md
+++ b/_avsitter2_lsl_examples_advanced/avsitter2_lsl_example_show_and_hide_prim_by_sittarget.md
@@ -13,10 +13,12 @@ default{
     changed(integer change){
         if(change & CHANGED_LINK){
             if(llAvatarOnSitTarget() == NULL_KEY){
-                llSetAlpha(1,ALL_SIDES);//visible
+                llSetAlpha(0,ALL_SIDES);//invisible
+                llSetLinkPrimitiveParamsFast(LINK_THIS, [PRIM_GLTF_BASE_COLOR, ALL_SIDES, "", "", "", "", "", 0.0, PRIM_GLTF_ALPHA_MODE_MASK, 1.0, ""]);
             }
             else{
-                llSetAlpha(0,ALL_SIDES);//invisible
+                llSetAlpha(1,ALL_SIDES);//visible
+                llSetLinkPrimitiveParamsFast(LINK_THIS, [PRIM_GLTF_BASE_COLOR, ALL_SIDES, "", "", "", "", "", "", "", "", ""]);
             }
         }
     }

--- a/_avsitter2_lsl_examples_advanced/avsitter2_lsl_example_show_and_hide_prim_by_sittarget.md
+++ b/_avsitter2_lsl_examples_advanced/avsitter2_lsl_example_show_and_hide_prim_by_sittarget.md
@@ -13,12 +13,12 @@ default{
     changed(integer change){
         if(change & CHANGED_LINK){
             if(llAvatarOnSitTarget() == NULL_KEY){
-                llSetAlpha(0,ALL_SIDES);//invisible
-                llSetLinkPrimitiveParamsFast(LINK_THIS, [PRIM_GLTF_BASE_COLOR, ALL_SIDES, "", "", "", "", "", 0.0, PRIM_GLTF_ALPHA_MODE_MASK, 1.0, ""]);
-            }
-            else{
                 llSetAlpha(1,ALL_SIDES);//visible
                 llSetLinkPrimitiveParamsFast(LINK_THIS, [PRIM_GLTF_BASE_COLOR, ALL_SIDES, "", "", "", "", "", "", "", "", ""]);
+            }
+            else{
+                llSetAlpha(0,ALL_SIDES);//invisible
+                llSetLinkPrimitiveParamsFast(LINK_THIS, [PRIM_GLTF_BASE_COLOR, ALL_SIDES, "", "", "", "", "", 0.0, PRIM_GLTF_ALPHA_MODE_MASK, 1.0, ""]);
             }
         }
     }


### PR DESCRIPTION
My artist friend asked me how to get your show/hide examples to work with PBR prims. I have made that update in my own script, but, never shared it. Here's a fix to your sample scripts. I also added these snippets to the lsl wiki:
- https://wiki.secondlife.com/wiki/LlSetAlpha
- https://wiki.secondlife.com/wiki/LlSetLinkAlpha
- https://wiki.secondlife.com/wiki/LlSetColor
- https://wiki.secondlife.com/wiki/LlSetLinkColor